### PR TITLE
Optional bat for new Windows Terminal

### DIFF
--- a/startAll-wt.bat
+++ b/startAll-wt.bat
@@ -1,0 +1,5 @@
+pushd "%~dp0" || exit /B
+start wt -w AlgoTrader --title "BackEnd" --tabColor #f2b78d uvicorn inventoryApi:app --reload
+cd my-app
+start wt -w AlgoTrader --title "FrontEnd" --tabColor #8df2ef "C:\Program Files\nodejs\node.exe" npm run dev
+popd


### PR DESCRIPTION
The "new" windows terminal supports titles and tabs. Nice QOL change to have the two CMDs grouped together. 
![image](https://github.com/akmayer/Warframe-Algo-Trader/assets/88603991/8225fa97-6478-443d-8bf4-0a4ec4c9ef80)

In my specific case, "npm" did not work when launching the bat file but worked perfectly when manually CDing into the directory and trying it. Replacing npm with your node executable works in this case. 
